### PR TITLE
Add Automatic Module Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,8 @@ license {
 tasks.named('jar', Jar) {
     manifest {
         attributes([
-            'Main-Class': 'net.minecraftforge.mcmaven.cli.Main'
+            'Main-Class': 'net.minecraftforge.mcmaven.cli.Main',
+            'Automatic-Module-Name': 'net.minecraftforge.mavenizer'
         ])
         attributes([
             'Specification-Title'   : projectDisplayName,


### PR DESCRIPTION
Add Automatic Module Name.

Due to having a "-" means the JDK cant come up with it itself.