### PR TITLE
Strip memory arguments from Decompiler task

### DIFF
--- a/src/main/java/net/minecraftforge/mcmaven/impl/Mavenizer.java
+++ b/src/main/java/net/minecraftforge/mcmaven/impl/Mavenizer.java
@@ -74,18 +74,61 @@ public final class Mavenizer {
     public static void setDecompileMemory(String value) {
         decompileMemory = value;
     }
-    public static List<String> fillDecompileJvmArgs(List<String> args) {
-        return fillJvmArgs(decompileMemory, args);
-    }
-    private static List<String> fillJvmArgs(@Nullable String mx, List<String> args) {
-        if (mx == null)
-            return args;
-        var ret = new ArrayList<String>();
-        ret.add("-Xmx" + mx);
-        for (var arg : args) {
-            if (arg.startsWith("-Xmx"))
+
+    // Default java argumetns are built build by the Image, and env variables
+    // https://github.com/openjdk/jdk/blob/08c8520b39083ec6354dc5df2f18c1f4c3588053/src/hotspot/share/runtime/arguments.cpp#L3628
+    private static final String[] DEFAULT_ARG_ENV = { "JAVA_OPTIONS", "_JAVA_OPTIONS", "JAVA_TOOL_OPIONS"};
+    private static final String[] MEMORY_FLAGS = {"-Xmx", "-XX:MaxHeapSize", "-Xms"};
+    private static void warnAboutMemory() {
+        var found = false;
+        for (var env : DEFAULT_ARG_ENV) {
+            var value = System.getenv(env);
+            if (value == null)
                 continue;
-            ret.add(arg);
+            for (var flag : MEMORY_FLAGS) {
+                if (value.contains(flag)) {
+                    LOGGER.warn("Detected Heap Size Argument(" + flag + ") in " + env + " environment variable.");
+                    found = true;
+                }
+            }
+        }
+        if (found)
+            LOGGER.warn("Please remove it if you run into memory related issues");
+    }
+
+    public static List<String> fillDecompileJvmArgs(List<String> args, boolean firstRun) {
+        if (!firstRun)
+            return args; // Use the unmodifed args from MCPConfig
+
+        var ret = stripMemoryJvmArgs(args);
+        // If we have an explicit memory size use it
+        if (decompileMemory != null) {
+            ret.add("-Xmx" + decompileMemory);
+        } else {
+            // Don't use any memory arguments and hope java picks the correct values
+            // By default it is 1/4th physical memory on modern JVMs
+            //     https://docs.oracle.com/en/java/javase/21/gctuning/ergonomics.html
+            // There are old JVMs that limit it to 1GB but there is no good way to detect if we're using one so just hope.
+            //     https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/ergonomics.html
+            // Best we can do is warn about memory argumetns if we see them.
+            warnAboutMemory();
+        }
+        return ret;
+    }
+
+    private static List<String> stripMemoryJvmArgs(List<String> args) {
+        var ret = new ArrayList<String>(args.size());
+
+        for (var arg : args) {
+            var skip = false;
+            for (var flag : MEMORY_FLAGS) {
+                if (arg.startsWith(flag)) {
+                    skip = true;
+                    break;
+                }
+            }
+            if (!skip)
+                ret.add(arg);
         }
         return ret;
     }

--- a/src/main/java/net/minecraftforge/mcmaven/impl/repo/mcpconfig/MCPTaskFactory.java
+++ b/src/main/java/net/minecraftforge/mcmaven/impl/repo/mcpconfig/MCPTaskFactory.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiPredicate;
+import java.util.function.ToIntFunction;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
@@ -903,10 +904,23 @@ public class MCPTaskFactory {
             throw new IllegalStateException("Failed to find JDK for version " + java_version, e);
         }
 
-        if (isDecompile)
-            jvm = Mavenizer.fillDecompileJvmArgs(jvm);
+        ToIntFunction<String> logHandler = null;
+        if (isDecompile) {
+            jvm = Mavenizer.fillDecompileJvmArgs(jvm, true);
+            logHandler = MCPTaskFactory::parseDecompileLog;
+        }
 
-        var ret = ProcessUtils.runJar(jdk, log.getParentFile(), log, tool, jvm, run, isDecompile ? MCPTaskFactory::parseDecompileLog : null);
+        var ret = ProcessUtils.runJar(jdk, log.getParentFile(), log, tool, jvm, run, logHandler);
+        if (ret.exitCode == OUT_OF_MEMORY && isDecompile) {
+            var newJvm = Mavenizer.fillDecompileJvmArgs(resolveArgs(cache, tasks, jvmArgs), false);
+            if (!newJvm.equals(jvm)) {
+                LOGGER.error("First decompile failed with OutOfMemory using JVM Args: " + jvm);
+                LOGGER.error("Attempting again with: " + newJvm);
+                ret = ProcessUtils.runJar(jdk, log.getParentFile(), log, tool, newJvm, run, logHandler);
+                if (ret.exitCode == OUT_OF_MEMORY)
+                    LOGGER.error("Ran out of memory again, you can specify more manually using the --decompile-memory Mavenizer argument");
+            }
+        }
         if (ret.exitCode != 0)
             throw new IllegalStateException("Failed to run MCP Step (exit code " + ret.exitCode + "), See log: " + log.getAbsolutePath());
 
@@ -967,6 +981,8 @@ public class MCPTaskFactory {
     // It also eagerly exits the process when something fails so as to not waste time.
     private static int parseDecompileLog(String line) {
         if (line.startsWith("java.lang.OutOfMemoryError:"))
+            return OUT_OF_MEMORY;
+        if (line.startsWith("Exception in thread") && line.contains("java.lang.OutOfMemoryError"))
             return OUT_OF_MEMORY;
         if (line.contains("ERROR:")) {
             // String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " in class " + cl.qualifiedName + " couldn't be written.";


### PR DESCRIPTION
Trust that java will allocate enough.
It used to allocate 1/4th physical RAM UP TO 1GB
But somewhere in the past they changed it to remove that 1GB upper limit.
So it's now just 1/4th physical memory.

I have verified that modern Java 8 uses the new unbound upper limit. But Java 8u51 has the limit.
So not sure exactly when it changed.

Anyways what this does is preserve the --decompile-memory argument.
If that argument is found it will be used in favor of anything else.
If that argument is not found, the jvm args will have memory related parameters stripped.
Functionally this just removes the the -Xmx4G from MCPConfig.
It'll also spit out a warning if we detect any memory related arguments in the default Java Environment Variables. 

If the first pass of decompiling fails with OOM, it will attempt to re-run using the jvm args from MCPConfig (basically falling back to old behavior)

If the second attempt fails, it errors as normal showing `Ran out of memory again, you can specify more manually using the --decompile-memory Mavenizer argument` and then the normal stack trace.

Here is an example run with `JAVA_OPTIONS=-X512G` set
```
Sources
  listLibraries
  extract[exceptions]
  download[1.15.2][server]
  stripServer
  stripClient
  merge
  rename
  extract[constructors]
  extract[access]
  mcinject
  modifyAccess
  stripSides
  decompile
    Detected Heap Size Argument(-Xmx) in JAVA_OPTIONS environment variable.
    Please remove it if you run into memory related issues
    First decompile failed with OutOfMemory using JVM Args: []
    Attempting again with: [-Xmx4G]
  extract[inject]
  inject
  patch
  patch[forge]
  downloadSources
  injectSources[forge]
  remap[forge][official-1.15.2][javadoc]
  remap[forge][official-1.15.2][javadoc][variants]
```

Here are some verifications for modern java versions:
```
java -XX:+PrintFlagsFinal -version | findstr HeapSize
    uintx ErgoHeapSizeLimit                         = 0                                   {product}
    uintx HeapSizePerGCThread                       = 87241520                            {product}
    uintx InitialHeapSize                          := 2145386496                          {product}
    uintx LargePageHeapSizeThreshold                = 134217728                           {product}
    uintx MaxHeapSize                              := 32210157568                         {product}
openjdk version "1.8.0_472"
OpenJDK Runtime Environment Corretto-8.472.08.1 (build 1.8.0_472-b08)
OpenJDK 64-Bit Server VM Corretto-8.472.08.1 (build 25.472-b08, mixed mode)

java -XX:+PrintFlagsFinal -version | findstr HeapSize
   size_t MaxHeapSize                              = 26843545600                               {product} {ergonomic}
openjdk version "17.0.12" 2024-07-16
IBM Semeru Runtime Open Edition 17.0.12.0 (build 17.0.12+7)
Eclipse OpenJ9 VM 17.0.12.0 (build openj9-0.46.0, JRE 17 Windows 11 amd64-64-Bit Compressed References 20240716_765 (JIT enabled, AOT enabled)
   
java -XX:+PrintFlagsFinal -version | findstr HeapSize
   size_t ErgoHeapSizeLimit                        = 0                                         {product} {default}
   size_t HeapSizePerGCThread                      = 43620760                                  {product} {default}
   size_t InitialHeapSize                          = 2147483648                                {product} {ergonomic}
   size_t LargePageHeapSizeThreshold               = 134217728                                 {product} {default}
   size_t MaxHeapSize                              = 31675383808                               {product} {ergonomic}
   size_t MinHeapSize                              = 16777216                                  {product} {ergonomic}
    uintx NonNMethodCodeHeapSize                   = 8192380                                {pd product} {ergonomic}
    uintx NonProfiledCodeHeapSize                  = 121732930                              {pd product} {ergonomic}
    uintx ProfiledCodeHeapSize                     = 121732930                              {pd product} {ergonomic}
   size_t SoftMaxHeapSize                          = 31675383808                            {manageable} {ergonomic}
openjdk version "21.0.6" 2025-01-21 LTS
OpenJDK Runtime Environment SapMachine (build 21.0.6+7-LTS)
OpenJDK 64-Bit Server VM SapMachine (build 21.0.6+7-LTS, mixed mode, sharing)
```