### PR TITLE
Fix cache miss on maven metadata caused by trailing `\n`

### DIFF
--- a/src/main/java/net/minecraftforge/mcmaven/impl/cache/MavenCache.java
+++ b/src/main/java/net/minecraftforge/mcmaven/impl/cache/MavenCache.java
@@ -246,7 +246,7 @@ public sealed class MavenCache permits MinecraftMavenCache {
 
                     try {
                         var chash = func.hash(target);
-                        if (!chash.equals(rhash)) {
+                        if (!rhash.startsWith(chash)) {
                             LOGGER.error("Outdated cached file: " + target.getAbsolutePath());
                             LOGGER.error("Expected: " + rhash);
                             LOGGER.error("Actual:   " + chash);


### PR DESCRIPTION
Fixes #32